### PR TITLE
Improve extras section

### DIFF
--- a/dist/PublicLab.Editor.css
+++ b/dist/PublicLab.Editor.css
@@ -37,6 +37,15 @@
 .ple-header {
   text-align: center;
 }
+@media (max-width:550px) {
+  a {
+      font-size: 0px !important;
+  }
+
+   a i {
+      font-size: 20px !important;
+   }
+}
 
 .ple-footer {
   padding: 10px;


### PR DESCRIPTION
Fixes #157
Mobile responsive extras section, using Bootstrap to hide the button text but not the icon (only at lower screen widths! <500px)

